### PR TITLE
Removed nuget package source that keeps causing login dialog to pop up.

### DIFF
--- a/CustomerService/NuGet.Config
+++ b/CustomerService/NuGet.Config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Package source {0}1" value="https://api.bintray.com/nuget/eventuateio-oss/eventuateio-dotnet-snapshots" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
api.bintray.com package source keeps causing a login dialog box to pop up on windows when attempting to open and build the project.